### PR TITLE
Use julia-shell-program to find version number

### DIFF
--- a/julia-shell.el
+++ b/julia-shell.el
@@ -128,7 +128,7 @@ By default, the following arguments are sent to julia:
   (let* ((julia-shell-program julia-shell-program)
          (buffer (get-buffer-create julia-shell-buffer-name))
          (julia-version
-          (shell-command-to-string "julia --version | awk '{print $3}'"))
+          (shell-command-to-string (concat julia-shell-program " --version | awk '{print $3}'")))
          (julia-emacsinit
           (expand-file-name "julia-shell-emacstools.jl"
                             (file-name-directory (locate-library "julia-shell"))))


### PR DESCRIPTION
Used to find version number of currently set julia-shell-program, useful if using git master in parallel with system-installed Julia.
